### PR TITLE
Make agency installation on-demand

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,10 +31,4 @@ RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Optionally install Agency tooling for AI-ready codespace configs
-ARG AI_READY="false"
-RUN if [ "$AI_READY" = "true" ]; then \
-        curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency; \
-    fi
-
 USER node

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -4,8 +4,7 @@
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {
-			"NODE_VERSION": "24",
-			"AI_READY": "true"
+			"NODE_VERSION": "24"
 		}
 	},
 	"runArgs": ["--init"],

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"generate:packageList:internal-test": "flub list client --no-private --feed internal-test --outFile feeds/internal-test.txt",
 		"generate:packageList:public": "flub list client --no-private --feed public --outFile feeds/public.txt",
 		"generate:packagesMd": "flub check layers --info layerInfo.json --md .",
+		"install:agency": "curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency",
 		"preinstall": "node scripts/only-pnpm.cjs",
 		"layer-check": "flub check layers --info layerInfo.json",
 		"lint": "fluid-build --task lint",

--- a/scripts/codespace-setup/ai-setup.sh
+++ b/scripts/codespace-setup/ai-setup.sh
@@ -6,4 +6,4 @@ source "$SCRIPT_DIR/agent-aliases.sh"
 
 bash "$SCRIPT_DIR/playwright-setup.sh"
 
-# Agency is installed via the Dockerfile for AI-ready codespace configs.
+# Agency can be installed on-demand via: pnpm run install:agency


### PR DESCRIPTION
## Summary
- Removed agency installation from the Dockerfile build step (removed `AI_READY` build arg)
- Added `install:agency` script to root package.json for on-demand installation
- Updated ai-setup.sh comment to reference the new script

## Test plan
- [ ] Verify AI-agent codespace builds without agency pre-installed
- [ ] Verify `pnpm run install:agency` installs agency correctly in a codespace
- [ ] Verify agent aliases still work after running the install script