### PR TITLE
feat: add PR review fleet workflow with parallel Copilot CLI agents

### DIFF
--- a/.changeset/plain-comics-bake.md
+++ b/.changeset/plain-comics-bake.md
@@ -1,0 +1,29 @@
+---
+"@fluidframework/tree": minor
+"__section": tree
+---
+
+Fixed incremental summary bug in SharedTree that may cause repeated summary failures eventually leading to document corruption
+
+Incremental summary for SharedTree is off by default. This bug only affects applications that have explicitly enabled incremental summarization.
+
+**Affected configurations**
+
+A session could be affected if all the following were true:
+
+- Incremental summarization was enabled (opt-in feature, off by default).
+- The SharedTree schema had incremental fields nested at least 2 levels deep. For example, a map field marked with `incrementalSummaryHint` that contains objects which themselves have a map field also marked with `incrementalSummaryHint`.
+- The document was summarized multiple times, with the outer incremental field changing in at least one summary while the inner incremental field remained unchanged.
+
+**Symptoms**
+
+Summaries would fail. Depending on the storage service, the error may appear as:
+
+- `TypeError: Cannot read properties of undefined (reading 'trees')` (for example, when using SharePoint storage)
+
+Repeated summary failures can cause a session to accumulate ops without a summary. Once the limit of ops without a summary is reached (~10k), further ops will be rejected, making the document read-only for that session.
+
+**Mitigation and recovery**
+
+- If a session is already affected, turning off incremental summarization will allow summaries to succeed again.
+- Upgrade to this version to prevent further summary failures.

--- a/.github/prompts/reviewers/api-compatibility.md
+++ b/.github/prompts/reviewers/api-compatibility.md
@@ -1,0 +1,91 @@
+# API Compatibility Reviewer
+
+You are an API compatibility reviewer analyzing a pull request for the Fluid Framework.
+
+## Context
+
+- **Repository**: __REPO__
+- **PR Number**: #__PR_NUMBER__
+
+## Your Focus
+
+Review the PR diff for **breaking changes, API surface modifications, and compatibility concerns**. Fluid Framework is a library consumed by external developers, so API stability is critical.
+
+## What to Look For
+
+1. **Breaking changes to public APIs**:
+   - Removed or renamed exported functions, classes, interfaces, or types
+   - Changed function signatures (new required parameters, removed parameters, changed types)
+   - Changed return types or removed return values
+   - Modified interface or type definitions that consumers implement or use
+   - Changed enum values or removed members
+
+2. **Deprecation concerns**:
+   - Deprecated APIs removed without sufficient deprecation period
+   - Missing `@deprecated` annotations on APIs being phased out
+   - Deprecation messages that don't guide users to replacements
+
+3. **Export changes**:
+   - Items removed from package entry points or barrel exports
+   - Changed export names or paths that consumers import from
+   - New exports that might conflict with common names
+
+4. **Behavioral changes to public APIs**:
+   - Changed semantics of existing methods (same signature but different behavior)
+   - Modified event emission patterns (new events, removed events, changed payloads)
+   - Changed error types or error conditions
+
+5. **Versioning signals**:
+   - Changes that warrant a major version bump vs minor vs patch
+   - Missing changeset entries for API changes
+
+## What to Ignore
+
+- Internal/private API changes (unexported, prefixed with `_`, or in `/internal/` paths)
+- Test file changes
+- Documentation-only changes
+- Performance changes that don't affect the API contract
+
+## Output Format
+
+Write your findings to `review-api-compatibility.md` using this format:
+
+```markdown
+## API Compatibility Review
+
+### Breaking Changes
+
+#### [SEVERITY] File: `path/to/file.ts` (lines X-Y)
+
+**Change**: Description of the API change.
+
+**Impact**: Who is affected and how (e.g., "Consumers calling `foo()` will get a type error").
+
+**Migration path**: How consumers should update their code.
+
+**Recommended action**: Whether this needs an API Council review, a deprecation period, or a changeset.
+
+---
+
+### Summary
+
+- **Breaking**: N changes (require major version bump)
+- **Deprecation**: N items (should be deprecated before removal)
+- **Minor**: N additions (new APIs, backwards-compatible)
+- **Patch**: N changes (bug fixes, no API impact)
+```
+
+If no issues are found, write:
+
+```markdown
+## API Compatibility Review
+
+No API compatibility concerns found. Changes are internal or backwards-compatible.
+```
+
+## Instructions
+
+1. Read the PR diff from the file `pr-diff.patch` in the current directory
+2. For files that export public APIs, read the full file and any related `.api.md` report files
+3. Pay special attention to changes in `index.ts`, barrel exports, and files under `src/`
+4. Write your review to `review-api-compatibility.md`

--- a/.github/prompts/reviewers/correctness.md
+++ b/.github/prompts/reviewers/correctness.md
@@ -1,0 +1,70 @@
+# Correctness Reviewer
+
+You are a correctness-focused code reviewer analyzing a pull request.
+
+## Context
+
+- **Repository**: __REPO__
+- **PR Number**: #__PR_NUMBER__
+
+## Your Focus
+
+Review the PR diff for **correctness issues only**. You are looking for bugs, logic errors, and functional regressions.
+
+## What to Look For
+
+1. **Logic errors**: Off-by-one, wrong comparisons, inverted conditions, missing null/undefined checks
+2. **Race conditions**: Concurrent access to shared state, missing awaits, unhandled promise rejections
+3. **Resource leaks**: Unclosed handles, missing cleanup in dispose/finally, event listener leaks
+4. **Error handling gaps**: Catch blocks that swallow errors silently, missing error propagation
+5. **Type safety**: Unsafe casts, `as any`, incorrect type narrowing, missing discriminant checks
+6. **Edge cases**: Empty arrays, zero-length strings, negative numbers, boundary values
+7. **Contract violations**: Breaking documented invariants, violating interface contracts
+
+## What to Ignore
+
+- Style, formatting, naming preferences
+- Performance unless it causes functional issues
+- Documentation or comments
+- Test coverage gaps (other reviewers handle this)
+
+## Output Format
+
+Write your findings to `review-correctness.md` using this format:
+
+```markdown
+## Correctness Review
+
+### Issues Found
+
+#### [SEVERITY] File: `path/to/file.ts` (lines X-Y)
+
+**Issue**: Brief description of the bug or logic error.
+
+**Why this matters**: Explain the concrete failure scenario.
+
+**Suggested fix**: Show the corrected code or describe the fix.
+
+---
+
+### Summary
+
+- **Critical**: N issues (bugs that will cause failures)
+- **Warning**: N issues (potential bugs under specific conditions)
+- **Info**: N issues (defensive improvements worth considering)
+```
+
+If no issues are found, write:
+
+```markdown
+## Correctness Review
+
+No correctness issues found. The logic and error handling in this PR look sound.
+```
+
+## Instructions
+
+1. Read the PR diff from the file `pr-diff.patch` in the current directory
+2. For files with complex changes, read the full file from the repo to understand context
+3. Focus only on changed lines and their immediate context
+4. Write your review to `review-correctness.md`

--- a/.github/prompts/reviewers/performance.md
+++ b/.github/prompts/reviewers/performance.md
@@ -1,0 +1,89 @@
+# Performance Reviewer
+
+You are a performance-focused code reviewer analyzing a pull request.
+
+## Context
+
+- **Repository**: __REPO__
+- **PR Number**: #__PR_NUMBER__
+
+## Your Focus
+
+Review the PR diff for **performance regressions and optimization opportunities** that matter at scale. Fluid Framework is a real-time collaboration library where latency and memory matter.
+
+## What to Look For
+
+1. **Algorithmic regressions**:
+   - O(n^2) or worse patterns introduced where O(n) or O(n log n) is feasible
+   - Repeated full-collection scans that could use an index or Map
+   - Unnecessary sorting or repeated sorting of the same data
+
+2. **Memory concerns**:
+   - Large object allocations in hot paths (inside loops, event handlers, per-operation code)
+   - Closures capturing large scopes unnecessarily
+   - Growing collections without bounds (unbounded caches, arrays that only push)
+   - Missing cleanup of event listeners, timers, or subscriptions
+
+3. **Async/concurrency issues**:
+   - Sequential awaits that could be parallelized with `Promise.all`
+   - Blocking operations in event handlers or hot paths
+   - Missing debouncing/throttling on high-frequency operations
+
+4. **Unnecessary work**:
+   - Computing values that are never used
+   - Re-creating objects/functions on every call when they could be cached or hoisted
+   - Redundant deep clones or serialization roundtrips
+   - Over-logging in production code paths
+
+5. **Data structure choices**:
+   - Array where Set/Map would be more appropriate for lookups
+   - Repeated `array.includes()` or `array.find()` on large collections
+   - String concatenation in loops instead of array join
+
+## What to Ignore
+
+- Micro-optimizations that don't affect real-world performance
+- Style or naming preferences
+- Performance of test code
+- One-time initialization code (startup cost is usually fine)
+
+## Output Format
+
+Write your findings to `review-performance.md` using this format:
+
+```markdown
+## Performance Review
+
+### Issues Found
+
+#### [SEVERITY] File: `path/to/file.ts` (lines X-Y)
+
+**Issue**: Description of the performance concern.
+
+**Impact**: Expected impact (e.g., "O(n^2) on every operation with n items in the tree").
+
+**Suggestion**: Specific optimization with code example if helpful.
+
+---
+
+### Summary
+
+- **Critical**: N issues (will cause noticeable performance degradation)
+- **Warning**: N issues (may cause issues at scale)
+- **Info**: N issues (minor optimizations worth considering)
+```
+
+If no issues are found, write:
+
+```markdown
+## Performance Review
+
+No performance concerns found. The changes look efficient and appropriate for the use case.
+```
+
+## Instructions
+
+1. Read the PR diff from the file `pr-diff.patch` in the current directory
+2. For performance-critical changes, read the full file to understand the hot path context
+3. Focus on code that runs per-operation, per-event, or in loops — not one-time setup
+4. Write your review to `review-performance.md`

--- a/.github/prompts/reviewers/security.md
+++ b/.github/prompts/reviewers/security.md
@@ -1,0 +1,74 @@
+# Security Reviewer
+
+You are a security-focused code reviewer analyzing a pull request.
+
+## Context
+
+- **Repository**: __REPO__
+- **PR Number**: #__PR_NUMBER__
+
+## Your Focus
+
+Review the PR diff for **security vulnerabilities and unsafe patterns**. You are an application security specialist.
+
+## What to Look For
+
+1. **Injection vulnerabilities**: Command injection, SQL injection, template injection, XSS, prototype pollution
+2. **Authentication/authorization**: Missing auth checks, privilege escalation, insecure token handling
+3. **Secrets exposure**: Hardcoded credentials, API keys in code, secrets in logs or error messages
+4. **Unsafe code evaluation**: Untrusted input passed to JSON.parse without validation, use of dynamic code execution functions, or string-to-code conversion patterns
+5. **Path traversal**: Unsanitized file paths from user input, directory escape via `../`
+6. **Dependency risks**: Newly added dependencies with known vulnerabilities, overly broad permissions
+7. **Cryptographic issues**: Weak algorithms, predictable random values for security purposes, timing attacks
+8. **Data exposure**: Sensitive data in logs, verbose error messages leaking internals, PII handling
+
+## What to Ignore
+
+- Code style, formatting, naming
+- Performance optimizations
+- General code quality (other reviewers handle this)
+- Test code (unless it exposes secrets)
+
+## Output Format
+
+Write your findings to `review-security.md` using this format:
+
+```markdown
+## Security Review
+
+### Vulnerabilities Found
+
+#### [SEVERITY] File: `path/to/file.ts` (lines X-Y)
+
+**Vulnerability**: Brief description (e.g., "Command injection via unsanitized user input").
+
+**Attack scenario**: How an attacker could exploit this.
+
+**Remediation**: Specific fix with code example.
+
+**References**: CWE or OWASP category if applicable.
+
+---
+
+### Summary
+
+- **Critical**: N issues (exploitable vulnerabilities)
+- **High**: N issues (likely exploitable with effort)
+- **Medium**: N issues (exploitable under specific conditions)
+- **Low**: N issues (defense-in-depth improvements)
+```
+
+If no issues are found, write:
+
+```markdown
+## Security Review
+
+No security vulnerabilities found in this PR. The changes follow secure coding practices.
+```
+
+## Instructions
+
+1. Read the PR diff from the file `pr-diff.patch` in the current directory
+2. For files with security-sensitive changes, read the full file to understand the complete security context
+3. Focus on changes that handle user input, authentication, file system access, or network communication
+4. Write your review to `review-security.md`

--- a/.github/prompts/reviewers/testing.md
+++ b/.github/prompts/reviewers/testing.md
@@ -1,0 +1,94 @@
+# Testing Reviewer
+
+You are a test-coverage reviewer analyzing a pull request.
+
+## Context
+
+- **Repository**: __REPO__
+- **PR Number**: #__PR_NUMBER__
+
+## Your Focus
+
+Review the PR diff for **test coverage gaps, test quality issues, and missing test scenarios**.
+
+## What to Look For
+
+1. **Missing test coverage**:
+   - New public functions/methods without corresponding tests
+   - New code branches (if/else, switch cases) not exercised by tests
+   - New error handling paths without tests that trigger them
+   - Changed behavior without updated tests to verify the new behavior
+
+2. **Test quality issues**:
+   - Tests that don't actually assert anything meaningful
+   - Tests that are tautological (testing that a mock returns what it was configured to return)
+   - Missing edge case coverage (empty inputs, boundary values, error conditions)
+   - Tests that are brittle or tightly coupled to implementation details
+   - Snapshot tests for logic that should have explicit assertions
+
+3. **Missing test scenarios**:
+   - Happy path covered but error paths missing
+   - Single-item tests but no multi-item or empty collection tests
+   - Synchronous behavior tested but async edge cases not covered
+   - Integration points tested in isolation but not together
+
+4. **Test maintenance**:
+   - Tests for removed code that should be deleted
+   - Test descriptions that no longer match what the test does
+   - Disabled/skipped tests without explanation
+
+## What to Ignore
+
+- Test style preferences (naming conventions, organization)
+- Test framework or tooling choices
+- Performance of test code
+- Code changes outside of test files (other reviewers handle production code)
+
+## Output Format
+
+Write your findings to `review-testing.md` using this format:
+
+```markdown
+## Testing Review
+
+### Gaps Found
+
+#### [PRIORITY] File: `path/to/source-file.ts`
+
+**Gap**: Description of missing test coverage.
+
+**Why it matters**: What could break without this test.
+
+**Suggested test**: Brief description or pseudocode of the test to add.
+
+```typescript
+// Example test case
+it("should handle empty input gracefully", () => {
+  const result = myFunction([]);
+  expect(result).toEqual([]);
+});
+```
+
+---
+
+### Summary
+
+- **Critical**: N gaps (core functionality untested)
+- **Important**: N gaps (significant paths untested)
+- **Nice to have**: N gaps (edge cases worth covering)
+```
+
+If no issues are found, write:
+
+```markdown
+## Testing Review
+
+Test coverage looks thorough. The PR includes appropriate tests for new and changed functionality.
+```
+
+## Instructions
+
+1. Read the PR diff from the file `pr-diff.patch` in the current directory
+2. Identify all production code changes and check if corresponding test changes exist
+3. For new functions or modified behavior, check if tests adequately cover the changes
+4. Write your review to `review-testing.md`

--- a/.github/workflows/pr-review-fleet.yml
+++ b/.github/workflows/pr-review-fleet.yml
@@ -1,0 +1,180 @@
+name: "PR Review Fleet"
+
+# Triggers a fleet of parallel Copilot CLI reviewer agents on every PR.
+# Each reviewer focuses on a different axis (correctness, security, performance, etc.)
+# and posts its findings as a PR comment.
+#
+# Setup requirements:
+#   1. Create a PAT with "Copilot Requests" permission
+#   2. Store it as a repository secret named COPILOT_GITHUB_TOKEN
+#   See: https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/automate-with-actions
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+      - next
+      - release/**/*
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel in-progress runs for the same PR when new commits are pushed.
+concurrency:
+  group: pr-review-fleet-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ──────────────────────────────────────────────────────────────
+  # Fan-out: run each reviewer in parallel via matrix strategy
+  # ──────────────────────────────────────────────────────────────
+  review:
+    name: "Review: ${{ matrix.reviewer }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Let all reviewers finish even if one fails
+      matrix:
+        reviewer:
+          - correctness
+          - security
+          - api-compatibility
+          - performance
+          - testing
+
+    steps:
+      # ── Checkout ──
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          # Fetch enough history to generate a meaningful diff against the base
+          fetch-depth: 0
+
+      # ── Prepare the diff ──
+      - name: Generate PR diff
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git diff "origin/${BASE_REF}...HEAD" > pr-diff.patch
+          echo "Generated diff: $(wc -l < pr-diff.patch) lines"
+
+      # ── Prepare the prompt ──
+      - name: Prepare reviewer prompt
+        env:
+          REVIEWER: ${{ matrix.reviewer }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          PROMPT_FILE=".github/prompts/reviewers/${REVIEWER}.md"
+          if [ ! -f "$PROMPT_FILE" ]; then
+            echo "::error::Prompt file not found: $PROMPT_FILE"
+            exit 1
+          fi
+
+          # Substitute context placeholders
+          sed -i "s|__REPO__|${REPO}|g" "$PROMPT_FILE"
+          sed -i "s|__PR_NUMBER__|${PR_NUMBER}|g" "$PROMPT_FILE"
+
+          echo "prompt_file=$PROMPT_FILE" >> "$GITHUB_OUTPUT"
+        id: prompt
+
+      # ── Install Copilot CLI ──
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
+
+      # ── Run the reviewer agent ──
+      - name: Run reviewer
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PROMPT_FILE: ${{ steps.prompt.outputs.prompt_file }}
+        timeout-minutes: 15
+        run: |
+          PROMPT=$(cat "$PROMPT_FILE")
+          copilot \
+            -p "$PROMPT" \
+            --allow-tool='shell(git:*)' \
+            --allow-tool='shell(cat:*)' \
+            --allow-tool='shell(head:*)' \
+            --allow-tool='shell(tail:*)' \
+            --allow-tool='shell(grep:*)' \
+            --allow-tool='shell(wc:*)' \
+            --allow-tool='shell(ls:*)' \
+            --allow-tool=read \
+            --allow-tool=write \
+            --no-ask-user
+
+      # ── Collect and post results ──
+      - name: Post review comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWER: ${{ matrix.reviewer }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          REVIEW_FILE="review-${REVIEWER}.md"
+
+          if [ ! -f "$REVIEW_FILE" ]; then
+            echo "No review output found ($REVIEW_FILE). Skipping comment."
+            exit 0
+          fi
+
+          # Build the comment body with a collapsible section
+          {
+            echo "### :robot: ${REVIEWER} review"
+            echo ""
+            echo "<details>"
+            echo "<summary>Click to expand</summary>"
+            echo ""
+            cat "$REVIEW_FILE"
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "---"
+            echo "*Automated review by PR Review Fleet — [${REVIEWER}](${RUN_URL})*"
+          } > comment-body.md
+
+          gh pr comment "${PR_NUMBER}" --body-file comment-body.md
+
+  # ──────────────────────────────────────────────────────────────
+  # Fan-in: post a summary comment after all reviewers complete
+  # ──────────────────────────────────────────────────────────────
+  summary:
+    name: "Review Summary"
+    needs: review
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          cat <<EOF > summary-body.md
+          ### :clipboard: PR Review Fleet Summary
+
+          All review agents have completed. See individual comments above for details.
+
+          | Reviewer | Focus |
+          |----------|-------|
+          | **correctness** | Bugs, logic errors, race conditions |
+          | **security** | Vulnerabilities, injection, secrets exposure |
+          | **api-compatibility** | Breaking changes, export modifications |
+          | **performance** | Algorithmic regressions, memory concerns |
+          | **testing** | Coverage gaps, missing test scenarios |
+
+          ---
+          *[View workflow run](${RUN_URL})*
+          EOF
+
+          gh pr comment "${PR_NUMBER}" --body-file summary-body.md

--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -86,7 +86,7 @@ The OCE rotation covers **three IcM teams**. Always search all three when lookin
 |---|---|---|---|---|
 | Build - client packages | 12 | `fluidframework/internal` | `ado` | `build`, `run_checks`, `publish_npm_internal_*` |
 | E2E tests | 56 | `fluidframework/internal` | `ado` | `e2e_odsp`, `e2e_local_server`, `e2e_azure_client_frs`, `e2e_azure_client_local_server` |
-| Stress tests | 63 | `fluidframework/internal` | `ado` | `stress_tests_frs`, `stress_tests_tinylicious` |
+| Stress tests | 63 | `fluidframework/internal` | `ado` | `stress_tests_odsp`, `stress_tests_odspdf`, `stress_tests_tinylicious`, `stress_tests_frs`, `stress_tests_frs_canary` |
 | Loop-FF integration | 29163 | `office/OC` | `ado-office` | `Build And Run E2E Tests`, `Build And Run Unit Tests`, `Lint and Type Check` |
 
 **ADO MCP servers:** Two ADO MCP servers are configured — `ado` (for `fluidframework` org) and `ado-office` (for `office` org). When querying pipelines in `office/OC` (e.g., Loop-FF integration pipeline def 29163), use the `ado-office` MCP server tools. All other pipelines use the default `ado` tools.
@@ -188,11 +188,17 @@ This section covers the tasks you may perform. You are not limited to these — 
 
 ### Azure Fluid Relay (FRS) Support
 
-- **Monitor FRS pipelines**: Check Stress (def 63) and E2E (def 56) for `main` and `lts`, specifically the `stress_tests_frs` and `e2e_frs` stages.
+- **Monitor FRS pipelines**: Check Stress (def 63) and E2E (def 56) for `main` and `lts`, specifically the `stress_tests_frs`, `stress_tests_frs_canary`, and `e2e_frs` stages. The FRS Canary stage (`stress_tests_frs_canary`) uses a separate FRS deployment and has its own variable group (`stress-frs-canary`) and Key Vault secret.
 
 - **Handle Tier 3 customer escalations**: When the FRS OCE team escalates a client-side issue, review IcM details, assess client-side nature, and begin investigation. Only Sev2+ triggers phone escalation.
 
 - **Escalate to FRS**: For FRS performance/reliability issues, help create a Sev3 IcM ticket via `https://aka.ms/frs/escalate` with description, Tenant ID, Document ID, and approximate time.
+
+- **Finding FRS test tenant IDs for escalation**: The stress test FRS credentials are stored as JSON secrets in `prague-key-vault`. Each secret is a JSON object with fields `discoveryEndpoint`, `host`, `tenantId`, `tenantSecret`, and `driverPolicies`. The `tenantId` field is what the FRS team needs.
+  - **`tools/getkeys` does NOT fetch these.** It explicitly skips secrets whose names start with `automation` (line 89 of `tools/getkeys/index.js`).
+  - To retrieve the tenant ID, someone with Key Vault access must run: `az keyvault secret show --vault-name prague-key-vault --name automation-fluid-driver-frs-canary-stress-test --query value -o tsv` (or use the Azure Portal). Parse the `tenantId` field from the returned JSON.
+  - The tenant ID is NOT logged in Kusto automation telemetry — you cannot extract it from queries.
+  - Key secrets: `automation-fluid-test-driver-frs-stress-test` (FRS prod), `automation-fluid-driver-frs-canary-stress-test` (FRS canary). Note: the naming convention is inconsistent between the two secrets.
 
 - **Update TSGs**: After resolution, help draft or update the relevant TSG on EngineeringHub.
 

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/SKILL.md
@@ -15,6 +15,8 @@ This skill provides a comprehensive reference for Fluid Framework telemetry inve
 - **Cluster:** `https://kusto.aria.microsoft.com`
 - **Primary database:** `Office Fluid`
 - **Database ID:** `6a8929bcfc6d44e9b13fee392ada9cf0` (use this, not the pretty name, as the `database` parameter in `kusto_query`)
+- **Automation/stress test database:** `Office Fluid Test`
+- **Database ID:** `742fa5a288b045e5beab1a2b8e445a71` — contains `office_fluid_ffautomation_*` tables used for stress test / pipeline telemetry. **These tables are NOT in the primary "Office Fluid" database.**
 - **Retention:** ~28 days
 - **VPN:** Required (Microsoft internal network)
 - **Access requirement:** M365HeartbeatTenantUsers group membership

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/references/kusto-query-reference.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/references/kusto-query-reference.md
@@ -36,8 +36,10 @@ This document is a comprehensive reference for Fluid Framework telemetry investi
 | `Office_Fluid_Video_Activity_GetPersonalOdbUrl` | ODB URL fetch events. `Activity_Success == false` signals failures. `Data_isExpected` marks expected failures (e.g. 404 for users without ODB). |
 | `Office_Fluid_Video_Activity_CreateRedeemableSharingLink` | Sharing link creation events for video. `Activity_Success == 'false'` for failures. |
 | `Office_Fluid_Video_Generic_Request` | Raw HTTP request events from the video component. Fields: `Data_status` (HTTP status code), `Data_clientRequestId`, `Data_requestId`, `Data_spRequestGuid`. |
-| `office_fluid_ffautomation_error` | Errors from stress test / automation runs. Fields: `Data_buildId`, `Data_driverType`, `Data_driverEndpointName`, `Data_profile`, `Data_branch`. Key field: `Data_hostName == "@fluid-internal/test-service-load"`. |
-| `union office_fluid_ffautomation*` | All automation tables — used for summarizer investigation in stress test runs (`DidSummarizerRecover`, `SummarizerView` queries). |
+| `office_fluid_ffautomation_error` | **Database: "Office Fluid Test" (ID `742fa5a288b045e5beab1a2b8e445a71`)** — NOT in the primary "Office Fluid" database. Errors from stress test / automation runs. Key columns: `Data_buildId`, `Data_driverType`, `Data_driverEndpointName` (values: `frs`, `frsCanary`, `odsp`, `odsp-df`, `local`), `Data_profile`, `Data_branch`, `Data_docId`, `Data_containerId`, `Data_eventName`, `Data_error`, `Data_errorType`, `Data_message`, `Data_stack`. Filter: `Data_hostName == "@fluid-internal/test-service-load"`. Note: tenant ID and service endpoint URLs are NOT logged in telemetry. |
+| `office_fluid_ffautomation_performance` | Same database as above. Performance/timing events from automation runs. Same key columns as `_error`. |
+| `office_fluid_ffautomation_generic` | Same database as above. Informational events from automation runs. Same key columns as `_error`. |
+| `union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic` | All automation tables. **Do NOT use wildcard `office_fluid_ffautomation*`** — the wildcard syntax does not resolve in this database. Always enumerate the three tables explicitly. |
 | `cluster('https://stream.eastus2.kusto.windows.net').database("OnePlayer").*` | OnePlayer (Stream video player) telemetry. Key fields: `playbackSessionId`, `userId`, `odspItemId`, `hostComponent`, `hostApp`, `result` (`"Fatal"` = error), `name`, `message`. EU cluster: `cluster('https://streameu.northeurope.kusto.windows.net')`. |
 
 **Shorthand for all FluidRuntime tables:**
@@ -1397,7 +1399,13 @@ union Office_Fluid_FluidRuntime_*
 
 ### 4.6 Stress Test Automation Queries
 
-**Source:** `summaryinvestigations` page, EngineeringHub. These queries run against `office_fluid_ffautomation*` tables (not `Office_Fluid_FluidRuntime_*`).
+**Database:** `Office Fluid Test` (ID `742fa5a288b045e5beab1a2b8e445a71`). These tables are **NOT** in the primary "Office Fluid" database.
+
+**Tables:** `office_fluid_ffautomation_error`, `office_fluid_ffautomation_performance`, `office_fluid_ffautomation_generic`. The wildcard `office_fluid_ffautomation*` does **NOT** resolve — always enumerate tables explicitly.
+
+**Key columns** (shared across all three tables): `Data_buildId`, `Data_driverType` (`odsp`, `routerlicious`, `tinylicious`), `Data_driverEndpointName` (`odsp`, `odsp-df`, `frs`, `frsCanary`, `local`), `Data_profile`, `Data_branch`, `Data_hostName`, `Data_docId`, `Data_containerId`, `Data_eventName`. Error table additionally has: `Data_error`, `Data_errorType`, `Data_message`, `Data_stack`.
+
+**Note:** Tenant IDs and service endpoint URLs are **not** logged in automation telemetry. To find the FRS Canary tenant ID, you must read the Key Vault secret `automation-fluid-driver-frs-canary-stress-test` from `prague-key-vault` (see OCE agent prompt for details).
 
 ```kusto
 // FindBuildErrors: All errors for a specific stress test run
@@ -1418,9 +1426,55 @@ office_fluid_ffautomation_error
 *Get the RunId from the failing ADO pipeline run. The pipeline logs show the buildId, driverType, and profile used.*
 
 ```kusto
+// CompareBuildHealth: Compare event volume, duration, and errors across builds per stage
+// Use to diagnose "pipeline suddenly started failing" — shows which stage regressed
+union withsource=TableName office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
+| where Event_Time between(datetime(2026-04-10) .. datetime(2026-04-17)) // adjust range
+    and Data_hostName == "@fluid-internal/test-service-load"
+    and Data_buildId in ("392069", "392243") // passing vs failing build IDs
+| summarize
+    TotalEvents=count(),
+    MinTime=min(Event_Time),
+    MaxTime=max(Event_Time),
+    Duration_minutes=datetime_diff('minute', max(Event_Time), min(Event_Time)),
+    DistinctDocs=dcount(Data_docId),
+    ErrorCount=countif(TableName == "office_fluid_ffautomation_error")
+    by Data_buildId, Data_driverType, Data_driverEndpointName
+| order by Data_buildId asc, Data_driverType asc
+```
+*Healthy stages typically show 100K–800K events in 20–45 min. A degraded stage shows dramatically fewer events (e.g. 6K) over a much longer duration (60+ min) with many errors.*
+
+```kusto
+// CompareBuildErrors: Side-by-side error breakdown for passing vs failing builds
+office_fluid_ffautomation_error
+| where Event_Time between(datetime(2026-04-10) .. datetime(2026-04-17)) // adjust range
+    and Data_hostName == "@fluid-internal/test-service-load"
+    and Data_buildId in ("392069", "392243") // passing vs failing build IDs
+| summarize ErrorCount=count(), DistinctDocs=dcount(Data_docId)
+    by Data_buildId, Data_eventName, Data_error, Data_errorType
+| order by Data_buildId asc, ErrorCount desc
+```
+
+```kusto
+// StageHealthTrend: Track a specific stage's health across all recent builds
+union withsource=TableName office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
+| where Event_Time > ago(7d)
+    and Data_hostName == "@fluid-internal/test-service-load"
+    and Data_driverEndpointName == "frsCanary" // change to stage of interest
+| summarize
+    TotalEvents=count(),
+    Duration_minutes=datetime_diff('minute', max(Event_Time), min(Event_Time)),
+    ErrorCount=countif(TableName == "office_fluid_ffautomation_error"),
+    DistinctDocs=dcount(Data_docId)
+    by Data_buildId
+| order by TotalEvents asc
+```
+*Sort by TotalEvents ascending to quickly spot degraded builds (low event count = test couldn't make progress).*
+
+```kusto
 // DidSummarizerRecover: Determine if the summarizer recovered after errors
 // Returns "true" if a successful summarize_end happened after the last error
-union office_fluid_ffautomation*
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Data_docId == "<docId>"
 | where Data_eventName in (
     "fluid:telemetry:Summarizer:Running:Summarize_end",
@@ -1440,7 +1494,7 @@ union office_fluid_ffautomation*
 
 ```kusto
 // SummarizerView: Full timeline of summarizer events for a document
-union office_fluid_ffautomation*
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Event_Time > ago(30d)
     and Data_clientType == 'noninteractive/summarizer'
     and Data_eventName contains "Summarizer:Running:"
@@ -1453,7 +1507,7 @@ union office_fluid_ffautomation*
 
 ```kusto
 // SummarizerLaunchRunView: Full summarizer manager + runner timeline
-union office_fluid_ffautomation*
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Event_Time > ago(30d)
     and (Data_eventName contains "fluid:telemetry:SummaryManager:"
         or Data_eventName contains "fluid:telemetry:Summarizer:Running")

--- a/DEV.md
+++ b/DEV.md
@@ -155,6 +155,7 @@ All workspace `pnpm-workspace.yaml` files include security-hardening settings to
 | `resolutionMode` | highest | Use highest matching version (see explanation below) |
 | `blockExoticSubdeps` | true | Block transitive deps from using git/tarball sources |
 | `trustPolicy` | no-downgrade | Fail if package trust/verification level decreases |
+| `trustPolicyExclude` | [] | Packages excluded from `trustPolicy` enforcement (see note below) |
 | `strictDepBuilds` | true | Require explicit approval for dependency build scripts |
 
 ### Why `resolutionMode: highest` instead of `time-based`
@@ -171,6 +172,12 @@ However, with `resolutionMode: time-based`, the "anchor" time for a transitive d
 This behavior is desired. However, pnpm does NOT attempt downward resolution to find a version that works (e.g., 1.0.0). Instead, it throws an error with no automatic fallback.
 
 With `resolutionMode: highest`, we still get protection from `minimumReleaseAge: 1440`, which blocks any package published within the last 24 hours. This provides supply chain protection without the transitive dependency resolution issues.
+
+### Trust Policy Exclusions (`trustPolicyExclude`)
+
+`trustPolicyExclude` lists packages that are exempt from `trustPolicy: no-downgrade` enforcement. This is needed for packages that are known to be safe but were published at a date after another version of the same package (including later major versions) that had better provenance information — causing pnpm to incorrectly treat the newer version as a trust downgrade.
+
+**This list must be reviewed carefully before adding any entry.** Only add a package here after confirming it is safe and understanding why its publication order triggers the policy.
 
 ### Build Script Approval (`strictDepBuilds`)
 

--- a/build-tools/pnpm-workspace.yaml
+++ b/build-tools/pnpm-workspace.yaml
@@ -16,4 +16,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/common/build/build-common/pnpm-workspace.yaml
+++ b/common/build/build-common/pnpm-workspace.yaml
@@ -13,4 +13,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/common/build/eslint-config-fluid/pnpm-workspace.yaml
+++ b/common/build/eslint-config-fluid/pnpm-workspace.yaml
@@ -13,4 +13,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/common/build/eslint-plugin-fluid/pnpm-workspace.yaml
+++ b/common/build/eslint-plugin-fluid/pnpm-workspace.yaml
@@ -13,4 +13,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/common/lib/common-utils/pnpm-workspace.yaml
+++ b/common/lib/common-utils/pnpm-workspace.yaml
@@ -13,4 +13,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/common/lib/protocol-definitions/pnpm-workspace.yaml
+++ b/common/lib/protocol-definitions/pnpm-workspace.yaml
@@ -13,4 +13,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -25,4 +25,10 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude:
+  - 'chokidar@4.0.3'
+  - 'semver@6.3.1 || 5.7.2'
 strictDepBuilds: true

--- a/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
@@ -50,10 +50,12 @@ interface ChunkLoadProperties {
 	 */
 	readonly encodedContents: EncodedFieldBatchV2;
 	/**
-	 * The path for this chunk's contents in the summary tree relative to the forest's summary tree.
-	 * This path is used to generate a summary handle for the chunk if it doesn't change between summaries.
+	 * The reference ID of this chunk's parent in the summary tree, or `undefined` if this chunk is
+	 * at the top level (directly under the forest summary tree).
+	 * Stored here so that {@link ForestIncrementalSummaryBuilder.decodeIncrementalChunk} can
+	 * reconstruct the correct {@link ChunkSummaryProperties} without re-parsing a path string.
 	 */
-	readonly summaryPath: string;
+	readonly parentReferenceId: ChunkReferenceId | undefined;
 }
 
 /**
@@ -68,10 +70,20 @@ interface ChunkSummaryProperties {
 	 */
 	readonly referenceId: ChunkReferenceId;
 	/**
-	 * The path for this chunk's summary in the summary tree relative to the forest's summary tree.
-	 * This path is used to generate a summary handle for the chunk if it doesn't change between summaries.
+	 * The reference ID of this chunk's parent in the summary tree, or `undefined` if this chunk
+	 * is at the top level (has no incremental parent).
+	 *
+	 * @remarks
+	 * Storing only the immediate parent (rather than the full path string) keeps every chunk's
+	 * tracking entry correct even when an ancestor is re-encoded and receives a new reference ID.
+	 * The full summary path is computed on demand by {@link ForestIncrementalSummaryBuilder.computeHandlePathInLatestSummary}
+	 * by walking up the parent chain through {@link TrackedSummaryProperties.latestSummaryRefIdMap}.
+	 *
+	 * If a parent chunk is encoded as a handle in the current summary its reference ID is unchanged,
+	 * so its children's `parentReferenceId` values copied forward by `completeSummary` remain valid
+	 * without any additional update.
 	 */
-	readonly summaryPath: string;
+	readonly parentReferenceId: ChunkReferenceId | undefined;
 }
 
 /**
@@ -109,6 +121,13 @@ interface TrackedSummaryProperties {
 	 * Serializes content (including {@link (IFluidHandle:interface)}s) for adding to a summary blob.
 	 */
 	stringify: SummaryElementStringifier;
+	/**
+	 * Reverse lookup map for the latest summary: maps each chunk's {@link ChunkReferenceId} to its
+	 * {@link ChunkSummaryProperties}.
+	 * Used by {@link ForestIncrementalSummaryBuilder.computeHandlePathInLatestSummary} to traverse
+	 * the parent chain when generating handle paths.
+	 */
+	readonly latestSummaryRefIdMap: Map<ChunkReferenceId, ChunkSummaryProperties>;
 }
 
 /**
@@ -177,6 +196,16 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 	/**
 	 * For a given summary sequence number, keeps track of a chunk's properties that will be used to generate
 	 * a summary handle for the chunk if it does not change between summaries.
+	 *
+	 * @remarks
+	 * `chunk` (the TreeChunk object) is used as the map key by object identity.
+	 * This assumes each chunk appears at exactly one position in the forest — an invariant that holds because every
+	 * node in a tree has a single parent.
+	 * If the forest ever introduced structural sharing (two positions backed by the same TreeChunk object),
+	 * a second call here would silently overwrite the first entry, causing the first position's handle to point
+	 * to the second position's parent in subsequent summaries. In theory, this should be fine from summary perspective
+	 * because the chunk contents are the same. But, it could lead to confusing handle paths in the summary tree and
+	 * may lead to other unexpected behavior. Adequate tests should be added if structural sharing is introduced.
 	 */
 	private readonly chunkTrackingPropertiesMap: NestedMap<
 		number,
@@ -249,12 +278,14 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 		// the contents of incremental chunks in any sub-trees.
 		const downloadChunkContentsInTree = async (
 			snapshotTree: ISnapshotTree,
-			parentTreeKey: string,
+			parentPathSegments: string[],
+			parentReferenceId: ChunkReferenceId | undefined,
 		): Promise<void> => {
 			// All trees in the snapshot tree are for incremental chunks. The key is the chunk's reference ID
 			// and the value is the snapshot tree for the chunk.
 			for (const [chunkReferenceId, chunkSnapshotTree] of Object.entries(snapshotTree.trees)) {
-				const chunkSubTreePath = `${parentTreeKey}${chunkReferenceId}`;
+				const chunkSubTreeSegments = [...parentPathSegments, chunkReferenceId];
+				const chunkSubTreePath = chunkSubTreeSegments.join("/");
 				const chunkContentsPath = `${chunkSubTreePath}/${summaryContentBlobKey}`;
 				if (!(await args.services.contains(chunkContentsPath))) {
 					throw new LoggingError(
@@ -266,7 +297,7 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 				)) as EncodedFieldBatchV2; // TODO: this should use a codec to validate the data instead of just type casting.
 				this.loadedChunksMap.set(chunkReferenceId, {
 					encodedContents: chunkContents,
-					summaryPath: chunkSubTreePath,
+					parentReferenceId,
 				});
 
 				const chunkReferenceIdNumber = Number(chunkReferenceId);
@@ -275,10 +306,15 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 				);
 
 				// Recursively download the contents of chunks in this chunk's sub tree.
-				await downloadChunkContentsInTree(chunkSnapshotTree, `${chunkSubTreePath}/`);
+				await downloadChunkContentsInTree(
+					chunkSnapshotTree,
+					chunkSubTreeSegments,
+					brand(chunkReferenceIdNumber),
+				);
 			}
 		};
-		await downloadChunkContentsInTree(forestTree, "");
+		// parentReferenceId is undefined for the root of the forest tree.
+		await downloadChunkContentsInTree(forestTree, [], undefined /* parentReferenceId */);
 	}
 
 	/**
@@ -319,6 +355,19 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 		}
 
 		this.latestSummarySequenceNumber = incrementalSummaryContext.latestSummarySequenceNumber;
+
+		// Build a reverse lookup map (referenceId → properties) for the latest summary so that
+		// computeHandlePathInLatestSummary can traverse the parent chain without iterating the whole map.
+		const latestSummaryRefIdMap: Map<ChunkReferenceId, ChunkSummaryProperties> = new Map();
+		const latestTracking = this.chunkTrackingPropertiesMap.get(
+			this.latestSummarySequenceNumber,
+		);
+		if (latestTracking !== undefined) {
+			for (const properties of latestTracking.values()) {
+				latestSummaryRefIdMap.set(properties.referenceId, properties);
+			}
+		}
+
 		this.trackedSummaryProperties = {
 			summarySequenceNumber: incrementalSummaryContext.summarySequenceNumber,
 			latestSummaryBasePath: incrementalSummaryContext.summaryPath,
@@ -326,8 +375,34 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 			parentSummaryBuilder: builder,
 			fullTree,
 			stringify,
+			latestSummaryRefIdMap,
 		};
 		return ForestIncrementalSummaryBehavior.Incremental;
+	}
+
+	/**
+	 * Computes a chunk's path in the latest summary by traversing up the parent chain via
+	 * {@link latestSummaryRefIdMap}.
+	 *
+	 * Each {@link ChunkSummaryProperties.parentReferenceId} points to the chunk's parent as it
+	 * appeared in the summary where the entry was last written. Walking up the chain from the
+	 * chunk to the root produces the full path that can be used in a summary handle path.
+	 */
+	private computeHandlePathInLatestSummary(chunkProperties: ChunkSummaryProperties): string {
+		const { latestSummaryRefIdMap } = this.requireTrackingSummary();
+		const pathSegments: string[] = [];
+		let current: ChunkSummaryProperties | undefined = chunkProperties;
+		while (current !== undefined) {
+			pathSegments.push(`${current.referenceId}`);
+			if (current.parentReferenceId === undefined) {
+				break;
+			}
+			current = latestSummaryRefIdMap.get(current.parentReferenceId);
+			assert(current !== undefined, "Parent chunk not found in latest summary tracking");
+		}
+		// Segments are collected leaf-to-root and then reversed. The alternative would be to use unshift
+		// instead of push and reverse. However, using push and reverse is O(n) whereas using unshift would be O(n²).
+		return pathSegments.reverse().join("/");
 	}
 
 	/**
@@ -344,8 +419,6 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 		const chunkReferenceIds: ChunkReferenceId[] = [];
 		const chunks = this.getChunkAtCursor(cursor);
 		for (const chunk of chunks) {
-			let chunkProperties: ChunkSummaryProperties;
-
 			// Try and get the properties of the chunk from the latest successful summary.
 			// If it exists and the summary is not a full tree, use the properties to generate a summary handle.
 			// If it does not exist, encode the chunk and generate new properties for it.
@@ -354,27 +427,28 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 				this.latestSummarySequenceNumber,
 				chunk,
 			);
+			let chunkReferenceId: ChunkReferenceId;
 			if (previousChunkProperties !== undefined && !trackedSummaryProperties.fullTree) {
-				chunkProperties = previousChunkProperties;
+				chunkReferenceId = previousChunkProperties.referenceId;
+				// Compute this chunk's path in the latest summary by traversing the parent chain.
+				// Using parentReferenceId traversal (rather than a stored path string) ensures the
+				// path is correct even when an ancestor was re-encoded in a prior summary and
+				// received a new referenceId — the stored summaryPath would have been stale in
+				// that case.
+				const handlePath = this.computeHandlePathInLatestSummary(previousChunkProperties);
 				trackedSummaryProperties.parentSummaryBuilder.addHandle(
-					`${chunkProperties.referenceId}`,
+					`${chunkReferenceId}`,
 					SummaryType.Tree,
-					`${trackedSummaryProperties.latestSummaryBasePath}/${chunkProperties.summaryPath}`,
+					`${trackedSummaryProperties.latestSummaryBasePath}/${handlePath}`,
 				);
 			} else {
 				// Generate a new reference ID for the chunk.
 				const newReferenceId: ChunkReferenceId = brand(this.nextReferenceId++);
+				chunkReferenceId = newReferenceId;
 
-				// Add the reference ID of this chunk to the chunk summary path and use the path as the summary path
-				// for the chunk in its summary properties.
-				// This is done before encoding the chunk so that the summary path is updated correctly when encoding
-				// any incremental chunks that are under this chunk.
+				// Add the reference ID of this chunk to the chunk summary path before encoding so
+				// that any incremental chunks in the subtree use the correct parent path.
 				trackedSummaryProperties.chunkSummaryPath.push(newReferenceId);
-
-				chunkProperties = {
-					referenceId: newReferenceId,
-					summaryPath: trackedSummaryProperties.chunkSummaryPath.join("/"),
-				};
 
 				const parentSummaryBuilder = trackedSummaryProperties.parentSummaryBuilder;
 				// Create a new summary builder for this chunk to build its summary tree which will be stored in the
@@ -400,13 +474,21 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 				trackedSummaryProperties.chunkSummaryPath.pop();
 			}
 
+			// Get the parent reference ID from the current chunk summary path.
+			// For the root of the forest tree, the parent reference ID is undefined.
+			// For all other chunks, the parent reference ID is the last element in the current chunk summary path.
+			const chunkSummaryPathLength = trackedSummaryProperties.chunkSummaryPath.length;
+			const parentReferenceId: ChunkReferenceId | undefined =
+				chunkSummaryPathLength > 0
+					? trackedSummaryProperties.chunkSummaryPath[chunkSummaryPathLength - 1]
+					: undefined;
 			setInNestedMap(
 				this.chunkTrackingPropertiesMap,
 				trackedSummaryProperties.summarySequenceNumber,
 				chunk,
-				chunkProperties,
+				{ referenceId: chunkReferenceId, parentReferenceId },
 			);
-			chunkReferenceIds.push(chunkProperties.referenceId);
+			chunkReferenceIds.push(chunkReferenceId);
 		}
 		return chunkReferenceIds;
 	}
@@ -480,9 +562,9 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 		referenceId: ChunkReferenceId,
 		chunkDecoder: (encoded: EncodedFieldBatchV2) => TreeChunk,
 	): TreeChunk {
-		const ChunkLoadProperties = this.loadedChunksMap.get(`${referenceId}`);
-		assert(ChunkLoadProperties !== undefined, 0xc86 /* Encoded incremental chunk not found */);
-		const chunk = chunkDecoder(ChunkLoadProperties.encodedContents);
+		const chunkLoadProperties = this.loadedChunksMap.get(`${referenceId}`);
+		assert(chunkLoadProperties !== undefined, 0xc86 /* Encoded incremental chunk not found */);
+		const chunk = chunkDecoder(chunkLoadProperties.encodedContents);
 
 		// Account for the reference about to be added in `chunkTrackingPropertiesMap`
 		// to ensure that no other users of this chunk think they have unique ownership.
@@ -493,7 +575,7 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 		// when a new client starts to summarize.
 		setInNestedMap(this.chunkTrackingPropertiesMap, this.initialSequenceNumber, chunk, {
 			referenceId,
-			summaryPath: ChunkLoadProperties.summaryPath,
+			parentReferenceId: chunkLoadProperties.parentReferenceId,
 		});
 		return chunk;
 	}

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -177,11 +177,10 @@ function validateHandlePathExists(handle: string, summaryTree: ISummaryTree) {
 				currentObject.type === SummaryType.Handle,
 				`Handle path ${handle} should be for a subtree or a handle`,
 			);
-			// This validation code currently can not validate paths that point inside a handle.
-			// Since it is currently not expected for this case to occur in these tests, fail to make sure we do not accidentally depend on this lack of validation.
-			assert.fail(
-				`Handle path ${handle} points inside a handle which is currently not supported by this validation code`,
-			);
+			// The path navigates into another handle, meaning the referenced subtree is itself
+			// reused from an even older summary. Fluid supports chained handle resolution, so
+			// this is valid — we simply cannot verify the deeper path without resolving the chain.
+			return;
 		}
 	}
 }
@@ -806,6 +805,462 @@ describe("ForestSummarizer", () => {
 					shouldContainHandle: true,
 					handleCount: itemsCount - 1,
 					lastSummary: summary1.summary,
+				});
+			});
+		});
+
+		describe("4-depth schema with parameterized incremental summarization", () => {
+			/**
+			 * A 4-depth nested schema where each level's map field carries
+			 * {@link incrementalSummaryHint}, creating 4 independent incremental chunks:
+			 * - Depth 1: the `documents` map (outermost chunk).
+			 * - Depth 2: each document's `sections` map.
+			 * - Depth 3: each section's `items` map.
+			 * - Depth 4: each item's `tags` map (innermost chunk).
+			 *
+			 * The root field `version` (depth 0) is non-incremental and does not belong to any chunk.
+			 */
+			/** Depth 4 (innermost): a single tag entry, contained within the `tags` incremental chunk. */
+			class Tag extends sf.object("Tag", {
+				name: sf.string,
+				value: sf.string,
+			}) {}
+
+			/** Depth 3: an item whose `tags` map is the depth-4 incremental chunk. */
+			class Item extends sf.object("Item", {
+				itemName: sf.string,
+				/**
+				 * The entire anonymous map of {@link Tag} entries is the depth-4 incremental chunk.
+				 */
+				tags: sf.types([{ type: sf.map(Tag), metadata: {} }], {
+					custom: { [incrementalSummaryHint]: true },
+				}),
+			}) {}
+
+			/** Depth 2: a section whose `items` map is the depth-3 incremental chunk. */
+			class Section extends sf.object("Section", {
+				sectionName: sf.string,
+				/**
+				 * The entire anonymous map of {@link Item} entries is the depth-3 incremental chunk.
+				 */
+				items: sf.types([{ type: sf.map(Item), metadata: {} }], {
+					custom: { [incrementalSummaryHint]: true },
+				}),
+			}) {}
+
+			/** Depth 1: a document whose `sections` map is the depth-2 incremental chunk. */
+			class Document extends sf.object("Document", {
+				docName: sf.string,
+				/**
+				 * The entire anonymous map of {@link Section} entries is the depth-2 incremental chunk.
+				 */
+				sections: sf.types([{ type: sf.map(Section), metadata: {} }], {
+					custom: { [incrementalSummaryHint]: true },
+				}),
+			}) {}
+
+			/** Depth 0 (root): workspace whose `documents` map is the depth-1 incremental chunk. */
+			class Workspace extends sf.object("Workspace", {
+				version: sf.string,
+				/**
+				 * The entire anonymous map of {@link Document} entries is the depth-1 incremental chunk.
+				 */
+				documents: sf.types([{ type: sf.map(Document), metadata: {} }], {
+					custom: { [incrementalSummaryHint]: true },
+				}),
+			}) {}
+
+			function setupForestSummarization(initialData: Workspace | undefined) {
+				const fieldCursor = initialData
+					? fieldCursorFromInsertable(Workspace, initialData)
+					: fieldJsonCursor([]);
+				const initialContent: TreeStoredContentStrict = {
+					schema: toStoredSchema(Workspace, permissiveStoredSchemaGenerationOptions),
+					initialTree: fieldCursor,
+				};
+				return createForestSummarizer({
+					initialContent,
+					encodeType: TreeCompressionStrategy.CompressedIncremental,
+					forestType: ForestTypeOptimized,
+					shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(
+						new TreeViewConfigurationAlpha({ schema: Workspace }),
+					),
+				});
+			}
+
+			const initialWorkspaceData = new Workspace({
+				version: "v1",
+				documents: {
+					Doc1: new Document({
+						docName: "Document 1",
+						sections: {
+							Sec1: new Section({
+								sectionName: "Section 1",
+								items: {
+									Item1: new Item({
+										itemName: "Item 1",
+										tags: {
+											Tag1: new Tag({ name: "tag1", value: "value1" }),
+										},
+									}),
+								},
+							}),
+						},
+					}),
+				},
+			});
+
+			/**
+			 * Mutates the tree at the given depth to trigger re-summarization of that depth and
+			 * all its ancestors (depths 0..changeDepth). Depths shallower than `changeDepth` (i.e.,
+			 * closer to the root) are always re-encoded because a changed child forces a new chunk
+			 * reference ID in the parent's encoding.
+			 *
+			 * - Depth 0: changes `version` (non-incremental root field). No chunks change; the
+			 * depth-1 chunk becomes a handle.
+			 * - Depth 1: changes `docName` inside the depth-1 documents chunk.
+			 * - Depth 2: changes `sectionName` inside the depth-2 sections chunk (also re-encodes depth 1).
+			 * - Depth 3: changes `itemName` inside the depth-3 items chunk (also re-encodes depths 1–2).
+			 * - Depth 4: changes a tag `name` inside the depth-4 tags chunk (re-encodes all depths; no handles).
+			 */
+			function makeChangeAtDepth(
+				workspace: Workspace,
+				depth: 0 | 1 | 2 | 3 | 4,
+				iteration: number,
+			): void {
+				const newVal = `updated-${iteration}`;
+				switch (depth) {
+					case 0: {
+						workspace.version = newVal;
+						break;
+					}
+					case 1: {
+						const doc = workspace.documents.get("Doc1");
+						assert(doc !== undefined, "Doc1 not found");
+						doc.docName = newVal;
+						break;
+					}
+					case 2: {
+						const doc = workspace.documents.get("Doc1");
+						assert(doc !== undefined, "Doc1 not found");
+						const sec = doc.sections.get("Sec1");
+						assert(sec !== undefined, "Sec1 not found");
+						sec.sectionName = newVal;
+						break;
+					}
+					case 3: {
+						const doc = workspace.documents.get("Doc1");
+						assert(doc !== undefined, "Doc1 not found");
+						const sec = doc.sections.get("Sec1");
+						assert(sec !== undefined, "Sec1 not found");
+						const item = sec.items.get("Item1");
+						assert(item !== undefined, "Item1 not found");
+						item.itemName = newVal;
+						break;
+					}
+					case 4: {
+						const doc = workspace.documents.get("Doc1");
+						assert(doc !== undefined, "Doc1 not found");
+						const sec = doc.sections.get("Sec1");
+						assert(sec !== undefined, "Sec1 not found");
+						const item = sec.items.get("Item1");
+						assert(item !== undefined, "Item1 not found");
+						const tag = item.tags.get("Tag1");
+						assert(tag !== undefined, "Tag1 not found");
+						tag.name = newVal;
+						break;
+					}
+					default: {
+						throw new Error(`Invalid depth: ${String(depth)}`);
+					}
+				}
+			}
+
+			/**
+			 * Test cases: each entry specifies an ordered sequence of depth changes.
+			 * Each change drives a new summary round; together they exercise different combinations
+			 * of chunk re-encoding and handle reuse.
+			 */
+			const testCases: {
+				name: string;
+				changeDepths: readonly (0 | 1 | 2 | 3 | 4)[];
+			}[] = [
+				{
+					name: "ascending depths 0→1→2→3→4",
+					changeDepths: [0, 1, 2, 3, 4],
+				},
+				{
+					name: "descending depths 4→3→2→1",
+					changeDepths: [4, 3, 2, 1],
+				},
+				{
+					name: "shallow then deep: depth 1 then 3",
+					changeDepths: [1, 3],
+				},
+				{
+					name: "deep then shallow: depth 3 then 1",
+					changeDepths: [3, 1],
+				},
+				{
+					name: "non-sequential: depth 2 then 4 then 1",
+					changeDepths: [2, 4, 1],
+				},
+				// The following test cases exercise the stale-handle-path bug: when a parent chunk
+				// is re-encoded in summary S(i), child handles inside it reference a summaryPath that
+				// was recorded when the child was last encoded as a full tree (possibly S0 or S1).
+				// In S(i+1), those handles are nested inside the newly-re-encoded parent, so their
+				// path must be resolvable in (i) (the latestSummary for (i+1)), not in an older one.
+				{
+					name: "same shallow depth twice: depth 1 then 1",
+					changeDepths: [1, 1],
+				},
+				{
+					name: "same depth twice: depth 2 then 2",
+					changeDepths: [2, 2],
+				},
+				{
+					name: "same depth three times: depth 1 then 1 then 1",
+					changeDepths: [1, 1, 1],
+				},
+				{
+					name: "shallow then same shallow twice: depth 2 then 1 then 1",
+					changeDepths: [2, 1, 1],
+				},
+				{
+					name: "deep then same shallow twice: depth 3 then 1 then 1",
+					changeDepths: [3, 1, 1],
+				},
+				{
+					name: "repeated shallow with deep interleaved: depth 1 then 2 then 1",
+					changeDepths: [1, 2, 1],
+				},
+				// The next two cases exercise the completeSummary copy-propagation path.
+				// When depth 0 changes, ALL incremental chunks become handles (or are not re-encoded
+				// at all). `completeSummary` then copies their tracking entries — including any stale
+				// summaryPath — forward to the new summary. On the following depth-1 (or depth-2)
+				// change, the parent chunk gets a new referenceId, so any child handle whose
+				// summaryPath was copied forward will point to a key that no longer exists in the
+				// preceding summary → BUG.
+				{
+					name: "stale path via copy propagation: depth 1, depth 0, depth 1",
+					changeDepths: [1, 0, 1],
+				},
+				{
+					name: "stale path via copy propagation: depth 2, depth 0, depth 2",
+					changeDepths: [2, 0, 2],
+				},
+			];
+
+			for (const { name, changeDepths } of testCases) {
+				it(`can incrementally summarize with ${name}`, () => {
+					const { checkout, forestSummarizer } =
+						setupForestSummarization(initialWorkspaceData);
+					const view = checkout.viewWith(new TreeViewConfiguration({ schema: Workspace }));
+
+					const summaries: ISummaryTree[] = [];
+
+					// Initial summary (no changes yet → no handles).
+					let seqNum = 0;
+					const initCtx: IExperimentalIncrementalSummaryContext = {
+						summarySequenceNumber: seqNum,
+						latestSummarySequenceNumber: -1,
+						summaryPath: "",
+					};
+					const initialSummaryResult = forestSummarizer.summarize({
+						stringify: JSON.stringify,
+						incrementalSummaryContext: initCtx,
+					});
+					validateSummaryIsIncremental(initialSummaryResult.summary);
+					validateHandlesInForestSummary(initialSummaryResult.summary, {
+						shouldContainHandle: false,
+					});
+					summaries.push(initialSummaryResult.summary);
+
+					for (let round = 0; round < changeDepths.length; round++) {
+						const changeDepth = changeDepths[round];
+						const prevSeqNum = seqNum;
+						seqNum = (round + 1) * 10;
+
+						// Apply the mutation at the specified depth.
+						makeChangeAtDepth(view.root, changeDepth, round);
+
+						// The first unchanged chunk (at depth changeDepth+1) becomes a handle. All
+						// deeper chunks are nested inside it and are not separately represented.
+						// If changeDepth === 4 (the max), every chunk was re-encoded → no handles.
+						const expectedHandleCount = changeDepth < 4 ? 1 : 0;
+
+						const ctx: IExperimentalIncrementalSummaryContext = {
+							summarySequenceNumber: seqNum,
+							latestSummarySequenceNumber: prevSeqNum,
+							summaryPath: "",
+						};
+						const summaryResult = forestSummarizer.summarize({
+							stringify: JSON.stringify,
+							incrementalSummaryContext: ctx,
+						});
+						summaries.push(summaryResult.summary);
+
+						if (expectedHandleCount === 0) {
+							validateHandlesInForestSummary(summaryResult.summary, {
+								shouldContainHandle: false,
+							});
+						} else {
+							// A handle's summaryPath must be resolvable in the immediately preceding
+							// summary (the latestSummary used during this round). That is summaries[round]
+							// because summaries[0] is the initial summary and summaries[i] is from round i-1.
+							validateHandlesInForestSummary(summaryResult.summary, {
+								shouldContainHandle: true,
+								handleCount: expectedHandleCount,
+								lastSummary: summaries[round],
+							});
+						}
+					}
+				});
+			}
+
+			it("simultaneous handles at depth 3 and depth 4 when only one section's items change", () => {
+				// Doc1 has two sections (Sec1 and Sec2). When Item1.itemName in Sec1 changes
+				// (a depth-3 change), depths 1–3 along the Sec1 branch are re-encoded:
+				//   depth 1: A (documents map)   — new tree
+				//   depth 2: B (Doc1.sections)   — new tree
+				//   depth 3: C1 (Sec1.items)     — new tree  (changed)
+				//   depth 3: C2 (Sec2.items)     — handle    (sibling of C1, unchanged)
+				//   depth 4: D1 (Item1.tags)     — handle    (child of C1, unchanged)
+				// Two handles at different depths appear in the same summary.
+				// Repeating the change exposes the stale-path bug for both C2 and D1: their
+				// stored summaryPaths still reference A and B's old referenceIds, so the handle
+				// URL points to keys that no longer exist in the preceding summary.
+				const twoSectionData = new Workspace({
+					version: "v1",
+					documents: {
+						Doc1: new Document({
+							docName: "Document 1",
+							sections: {
+								Sec1: new Section({
+									sectionName: "Section 1",
+									items: {
+										Item1: new Item({
+											itemName: "Item 1",
+											tags: { Tag1: new Tag({ name: "tag1", value: "value1" }) },
+										}),
+									},
+								}),
+								Sec2: new Section({
+									sectionName: "Section 2",
+									items: {
+										Item1: new Item({
+											itemName: "Item 2",
+											tags: { Tag1: new Tag({ name: "tag2", value: "value2" }) },
+										}),
+									},
+								}),
+							},
+						}),
+					},
+				});
+				const { checkout, forestSummarizer } = setupForestSummarization(twoSectionData);
+				const view = checkout.viewWith(new TreeViewConfiguration({ schema: Workspace }));
+				const summaries: ISummaryTree[] = [];
+
+				let seqNum = 0;
+				const initResult = forestSummarizer.summarize({
+					stringify: JSON.stringify,
+					incrementalSummaryContext: {
+						summarySequenceNumber: seqNum,
+						latestSummarySequenceNumber: -1,
+						summaryPath: "",
+					},
+				});
+				validateHandlesInForestSummary(initResult.summary, { shouldContainHandle: false });
+				summaries.push(initResult.summary);
+
+				for (let round = 0; round < 3; round++) {
+					const prevSeqNum = seqNum;
+					seqNum = (round + 1) * 10;
+
+					// Change Item1.itemName in Sec1 — re-encodes A, B, C1 as new trees.
+					const doc1 = view.root.documents.get("Doc1");
+					assert(doc1 !== undefined, "Doc1 not found");
+					const sec1 = doc1.sections.get("Sec1");
+					assert(sec1 !== undefined, "Sec1 not found");
+					const item1 = sec1.items.get("Item1");
+					assert(item1 !== undefined, "Item1 not found");
+					item1.itemName = `updated-${round}`;
+
+					const result = forestSummarizer.summarize({
+						stringify: JSON.stringify,
+						incrementalSummaryContext: {
+							summarySequenceNumber: seqNum,
+							latestSummarySequenceNumber: prevSeqNum,
+							summaryPath: "",
+						},
+					});
+					summaries.push(result.summary);
+
+					// C2 (Sec2.items, depth 3) and D1 (Item1.tags, depth 4) are both handles.
+					// Both handle paths must be resolvable in the immediately preceding summary.
+					validateHandlesInForestSummary(result.summary, {
+						shouldContainHandle: true,
+						handleCount: 2,
+						lastSummary: summaries[round],
+					});
+				}
+			});
+
+			it("fullTree summary forces all chunks to re-encode; subsequent incremental summary creates handles", () => {
+				const { checkout, forestSummarizer } = setupForestSummarization(initialWorkspaceData);
+				const view = checkout.viewWith(new TreeViewConfiguration({ schema: Workspace }));
+
+				let seqNum = 0;
+
+				// Initial incremental summary — no handles.
+				const initCtx: IExperimentalIncrementalSummaryContext = {
+					summarySequenceNumber: seqNum,
+					latestSummarySequenceNumber: -1,
+					summaryPath: "",
+				};
+				const initResult = forestSummarizer.summarize({
+					stringify: JSON.stringify,
+					incrementalSummaryContext: initCtx,
+				});
+				validateHandlesInForestSummary(initResult.summary, { shouldContainHandle: false });
+
+				// fullTree=true summary: no handles even though nothing changed.
+				seqNum = 10;
+				const fullTreeCtx: IExperimentalIncrementalSummaryContext = {
+					summarySequenceNumber: seqNum,
+					latestSummarySequenceNumber: 0,
+					summaryPath: "",
+				};
+				const fullTreeResult = forestSummarizer.summarize({
+					stringify: JSON.stringify,
+					incrementalSummaryContext: fullTreeCtx,
+					fullTree: true,
+				});
+				validateHandlesInForestSummary(fullTreeResult.summary, {
+					shouldContainHandle: false,
+				});
+
+				// Now make a change at depth 1 and take an incremental summary.
+				const doc1 = view.root.documents.get("Doc1");
+				assert(doc1 !== undefined, "Doc1 not found");
+				doc1.docName = "Updated";
+				seqNum = 20;
+				const incrCtx: IExperimentalIncrementalSummaryContext = {
+					summarySequenceNumber: seqNum,
+					latestSummarySequenceNumber: 10,
+					summaryPath: "",
+				};
+				const incrResult = forestSummarizer.summarize({
+					stringify: JSON.stringify,
+					incrementalSummaryContext: incrCtx,
+				});
+				// The sections chunk inside Doc1 is unchanged → 1 handle pointing into the
+				// fullTree summary (the latest summary).
+				validateHandlesInForestSummary(incrResult.summary, {
+					shouldContainHandle: true,
+					handleCount: 1,
+					lastSummary: fullTreeResult.summary,
 				});
 			});
 		});

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -133,7 +133,7 @@ export function benchmarkAll<T extends IBenchmarkParameters>(
 				// These tests are quite slow, so force a really low iteration count.
 				// If we need better data at some point, we can look into raising it.
 				keepIterations: Math.min(obj.minSampleCount ?? 1, 1),
-				warmUpIterations: (obj.minSampleCount ?? 1 > 1) ? 1 : 0,
+				warmUpIterations: (obj.minSampleCount ?? 1) > 1 ? 1 : 0,
 				benchmarkFn: async (state: MemoryUseCallbacks) => {
 					await obj.before?.();
 					while (state.continue()) {

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -65,7 +65,7 @@ describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObject
 		...benchmarkMemoryUse(
 			memoryUseOfValue(async () => loader.createDetachedContainer(codeDetails)),
 		),
-	});
+	}).timeout(60000);
 
 	benchmarkIt({
 		title: "Create detached container and attach it",
@@ -76,7 +76,7 @@ describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObject
 				return container;
 			}),
 		),
-	});
+	}).timeout(60000);
 
 	benchmarkIt({
 		title: "Load existing container",
@@ -86,5 +86,5 @@ describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObject
 				return loader.resolve({ url: requestUrl });
 			}),
 		),
-	});
+	}).timeout(60000);
 });

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -58,7 +58,7 @@ describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObject
 	benchmarkIt({
 		title: "Create loader",
 		...benchmarkMemoryUse(memoryUseOfValue(() => createLoader())),
-	});
+	}).timeout(60000);
 
 	benchmarkIt({
 		title: "Create detached container",

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -147,5 +147,5 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 				return summary;
 			}),
 		),
-	});
+	}).timeout(60000);
 });

--- a/server/gitrest/pnpm-workspace.yaml
+++ b/server/gitrest/pnpm-workspace.yaml
@@ -23,4 +23,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/server/historian/pnpm-workspace.yaml
+++ b/server/historian/pnpm-workspace.yaml
@@ -26,4 +26,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/server/routerlicious/pnpm-workspace.yaml
+++ b/server/routerlicious/pnpm-workspace.yaml
@@ -27,4 +27,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/tools/api-markdown-documenter/pnpm-workspace.yaml
+++ b/tools/api-markdown-documenter/pnpm-workspace.yaml
@@ -19,4 +19,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.57.0
 
+-   Error messages from Mocha, including timeouts, are now included in the console and output files properly.
+
 ## 0.56.0
 
 -   Add `after` to `MemoryUseModifier`.

--- a/tools/benchmark/pnpm-workspace.yaml
+++ b/tools/benchmark/pnpm-workspace.yaml
@@ -18,4 +18,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/tools/benchmark/src/mocha/Reporter.ts
+++ b/tools/benchmark/src/mocha/Reporter.ts
@@ -15,10 +15,10 @@ import {
 } from "../reporterUtilities.js";
 import {
 	type BenchmarkResult,
-	type BenchmarkError,
 	parseBenchmarkResult,
 	type ReportArray,
 	type ReportEntry,
+	isResultError,
 } from "../reportTypes.js";
 import { assert } from "../assert.js";
 import { isChildProcess } from "../Configuration.js";
@@ -47,6 +47,19 @@ module.exports = class {
 	public constructor(runner: Runner, options?: { reporterOptions?: ReporterOptions }) {
 		this.reportFile = options?.reporterOptions?.reportFile;
 		runner
+			.on(Runner.constants.EVENT_TEST_FAIL, (test: Test, err: unknown) => {
+				const existing = this.testData.get(test.id);
+				if (existing !== undefined && isResultError(existing.data)) {
+					// If benchmark already reported an error, don't overwrite it.
+					return;
+				}
+				// Store the failure as a BenchmarkError in testData so EVENT_TEST_END can use it.
+				// EVENT_TEST_FAIL always fires before EVENT_TEST_END, so this is always set in time.
+				// Checking for test.err in EVENT_TEST_END does not appear to work, so we do this instead.
+
+				const error = err instanceof Error ? err.message : String(err);
+				this.testData.set(test.id, { benchmarkName: test.title, data: { error } });
+			})
 			.on(Runner.constants.EVENT_SUITE_BEGIN, (suite: Suite) => {
 				const parent = suite.parent;
 				if (parent === undefined || parent === null) {
@@ -101,22 +114,24 @@ module.exports = class {
 
 				const suiteData = this.getSuiteData(test.parent);
 
+				// If we do not already have an error result, consider setting one:
+				if (benchmark === undefined || !isResultError(benchmark)) {
+					// The mocha test reported an error.
+					// Mocha does not always set test.err when a test fails with an error (for example timeout errors),
+					// so we have EVENT_TEST_FAIL as well.
+					if (test.err) {
+						benchmark = { error: test.err.message };
+					}
+				}
+
 				if (benchmark === undefined) {
-					// Mocha test completed without reporting data.
-					// This is an error, so report it as such.
-					const error = `Test ${test.fullTitle()} completed with status '${
-						test.state
-					}' without reporting any data.`;
-					benchmark = { error };
-				} else if (test.state !== "passed") {
-					// The mocha test failed after reporting benchmark data.
-					// This may indicate the benchmark did not measure what was intended, so mark as aborted.
-					const error =
-						(benchmark as BenchmarkError).error ??
-						`Test ${test.fullTitle()} completed with status '${
+					// Mocha test completed without emitting benchmark data and without a recorded failure.
+					// This can happen if the test passed without calling emitResultsMocha.
+					benchmark = {
+						error: `Test ${test.fullTitle()} completed with status '${
 							test.state
-						}' after reporting data.`;
-					benchmark = { error };
+						}' without reporting any data or an error.`,
+					};
 				}
 
 				const report: ReportEntry = { benchmarkName: test.title, data: benchmark };

--- a/tools/benchmark/src/test/mocha/integration.spec.ts
+++ b/tools/benchmark/src/test/mocha/integration.spec.ts
@@ -24,49 +24,54 @@ const sampleResult: CollectedData = [
 const perfModeArgs = ["--perfMode", "--reporter", "./dist/mocha/Reporter.js"];
 
 describe("mocha integration", () => {
-	function integrationTest(testArgs: string[], shouldFail: boolean): string {
+	function integrationTest(
+		testArgs: string[],
+		shouldFail: boolean,
+		options?: {
+			/** Defaults to "mocha-integration-inner". */
+			testName?: string;
+			env?: NodeJS.ProcessEnv;
+		},
+	): { stdout: string; stderr: string } {
 		// Disable colors with "--no-color" does not seem to work on CI (perhaps due to an environment variable),
 		// but enabling colors does seem to work locally, so we enable colors to get consistent results for these tests.
-		const args = [...testArgs, "--fgrep", "mocha-integration-inner", "--color"];
-		if (shouldFail) {
-			args.push("--integrationFail");
-		}
-		const result = childProcess.spawnSync("mocha", args, { encoding: "utf8" });
+		const testName = options?.testName ?? "mocha-integration-inner";
+		const args = [...testArgs, "--fgrep", testName, "--color"];
+		const result = childProcess.spawnSync("mocha", args, {
+			encoding: "utf8",
+			env: options?.env,
+		});
 		assert.equal(result.status, shouldFail ? 1 : 0);
-		if (shouldFail) {
-			// The error should always make it to the output when failing.
-			assert.match(result.stdout, /Example Error/);
-		}
-		return result.stdout;
+		return { stdout: result.stdout, stderr: result.stderr };
 	}
 
 	it("correctness", () => {
-		const result = integrationTest([], false);
-		assert.match(result, /✔.*@Benchmark @Measurement mocha-integration-inner/);
-		assert.match(result, / 1 passing/);
+		const { stdout } = integrationTest([], false);
+		assert.match(stdout, /✔.*@Benchmark @Measurement mocha-integration-inner/);
+		assert.match(stdout, / 1 passing/);
 	});
 
 	it("correctness with error", () => {
-		const result = integrationTest(["--integrationFail"], true);
-		assert.match(result, / 0 passing/);
+		const { stdout } = integrationTest(["--integrationFail"], true);
+		assert.match(stdout, / 0 passing/);
 	});
 	for (const parentProcess of [false, true]) {
 		describe(parentProcess ? "with parent process" : "without parent process", () => {
 			const args = [...perfModeArgs, ...(parentProcess ? ["--parentProcess"] : [])];
 			it("perf", () => {
-				const result = integrationTest(args, false);
+				const { stdout } = integrationTest(args, false);
 				// From suite table:
-				assert.match(result, /✔.+mocha-integration-inner.+1\.000 ms/);
+				assert.match(stdout, /✔.+mocha-integration-inner.+1\.000 ms/);
 				// From summary table:
-				assert.match(result, /✔.+mocha integration.+1 out of 1 /);
+				assert.match(stdout, /✔.+mocha integration.+1 out of 1 /);
 			});
 
 			it("perf with error", () => {
-				const result = integrationTest([...args, "--integrationFail"], true);
+				const { stdout } = integrationTest([...args, "--integrationFail"], true);
 				// From suite table:
-				assert.match(result, /×.+mocha-integration-inner.+Example Error/);
+				assert.match(stdout, /×.+mocha-integration-inner.+Example Error/);
 				// From summary table:
-				assert.match(result, /×.+mocha integration.+0 out of 1/);
+				assert.match(stdout, /×.+mocha integration.+0 out of 1/);
 			});
 		});
 	}
@@ -81,6 +86,43 @@ describe("mocha integration", () => {
 			return sampleResult;
 		},
 	});
+
+	it("timeout message", () => {
+		// Run the timeout inner test (registered only when --integrationTimeout is passed)
+		// with a 1ms mocha timeout so it always times out before emitting benchmark data.
+		const { stderr } = integrationTest(
+			[
+				...perfModeArgs,
+				"--integrationTimeout",
+				// Without --exit, the 60s sleep in the inner test keeps the subprocess alive long after
+				// the mocha timeout fires, hanging this test for a full minute.
+				"--exit",
+			],
+			true,
+			{
+				testName: "timeout-integration-inner",
+				// FLUID_TEST_VERBOSE prevents @fluid-internal/mocha-test-setup from suppressing
+				// console.error during test execution, so the timeout error reaches stderr.
+				env: { ...process.env, FLUID_TEST_VERBOSE: "1" },
+			},
+		);
+		// The table in stdout truncates the error, so check stderr:
+		assert.match(stderr, /Timeout of 1ms exceeded/);
+	});
+
+	// Test run by the "timeout message" integration test above.
+	// Only registered when --integrationTimeout is passed, to avoid running a deliberately
+	// failing test during normal test runs.
+	if (argv.includes("--integrationTimeout")) {
+		benchmarkIt({
+			title: "timeout-integration-inner",
+			run: async (): Promise<CollectedData> => {
+				// Sleep far longer than the 1ms timeout below so this always times out.
+				await new Promise<void>((resolve) => setTimeout(resolve, 60_000));
+				return sampleResult;
+			},
+		}).timeout(1);
+	}
 });
 
 benchmarkIt({

--- a/tools/getkeys/pnpm-workspace.yaml
+++ b/tools/getkeys/pnpm-workspace.yaml
@@ -12,4 +12,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true

--- a/tools/test-tools/pnpm-workspace.yaml
+++ b/tools/test-tools/pnpm-workspace.yaml
@@ -18,4 +18,8 @@ minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+# List of packages known to be safe but for whatever reason were published at a date after another version of the same
+# package (including later major versions) which had better provenance information.
+# ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
+trustPolicyExclude: []
 strictDepBuilds: true


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`pr-review-fleet.yml`) triggered on PRs that fans out five parallel Copilot CLI reviewer agents
- Each reviewer focuses on a different axis: correctness, security, API compatibility, performance, and testing
- Results are posted as collapsible PR comments, with a summary table after all reviewers complete

## Reviewer Prompts

Prompt files live in `.github/prompts/reviewers/` and can be edited independently without touching the workflow:

| Reviewer | Focus |
|----------|-------|
| **correctness** | Bugs, logic errors, race conditions, resource leaks |
| **security** | Injection, secrets exposure, unsafe patterns |
| **api-compatibility** | Breaking changes, export modifications, deprecation |
| **performance** | Algorithmic regressions, memory concerns |
| **testing** | Coverage gaps, missing edge cases, test quality |

## Setup Required

1. Create a PAT with "Copilot Requests" permission
2. Store it as repository secret `COPILOT_GITHUB_TOKEN`

## Test plan

- [ ] Verify workflow triggers on a test PR
- [ ] Confirm Copilot CLI installs and authenticates successfully
- [ ] Check that each reviewer agent produces output and posts a PR comment
- [ ] Verify concurrency cancellation works when pushing new commits