### PR TITLE
fix(build-tools): fix CJS type test build compatibility

### DIFF
--- a/build-tools/packages/build-tools/index.d.cts
+++ b/build-tools/packages/build-tools/index.d.cts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Workaround TypeScript distrust of importing ESM in CJS use
+//  error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'.
+// Only type exports from typeCompatibility.ts are needed in support of type test
+// infrastructure and that is CJS-ESM agnostic.
+// (Node 22+ supports synchronous ESM load via require under certain conditions.
+// build-tools has not been investigated for this use as there is no known need.)
+export type * from "./dist/common/typeCompatibility.js";

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -13,11 +13,12 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"default": "./dist/index.js"
+			"require": {
+				"types": "./index.d.cts"
+			},
+			"import": "./dist/index.js"
 		}
 	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"bin": {
 		"fluid-build": "bin/fluid-build.mjs",
 		"fluid-doc-stats": "bin/fluid-doc-stats.mjs",

--- a/build-tools/packages/build-tools/src/common/typeCompatibility.ts
+++ b/build-tools/packages/build-tools/src/common/typeCompatibility.ts
@@ -12,9 +12,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * The types defined here cannot be in build-cli because it is an ESM-only package, and these types are imported in
- * packages that are dual-emit or CJS-only. Long term these types should move to a shared library between build-cli and
- * build-tools.
+ * Type compatibility utilities for generated type tests.
+ *
+ * These types must be available in CommonJS use case for consumers to type
+ * test against CommonJS build.
+ * As this package is ESM-only and TypeScript (as of 5.4.5) has not been
+ * configured to permit Node 22+ support of synchronous ESM load under CJS,
+ * a special workaround is needed. package.json exports list a special case
+ * for require+types referencing a simple .d.cts file re-exporting the
+ * ESM exports that are required.
  */
 
 /**

--- a/build-tools/packages/build-tools/src/common/typeCompatibility.ts
+++ b/build-tools/packages/build-tools/src/common/typeCompatibility.ts
@@ -12,67 +12,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Type compatibility utilities for generated type tests.
- *
- * ## Why this file is .cts (CommonJS TypeScript)
- *
- * This file uses the `.cts` extension to produce CommonJS output (`.cjs` and `.d.cts`) even though
- * the `@fluidframework/build-tools` package is ESM-only (`"type": "module"` in package.json).
- *
- * ### The Problem
- *
- * The generated type test files (e.g., `validateFooPrevious.generated.ts`) import these type utilities:
- *
- * ```ts
- * import type { TypeOnly, MinimalType, FullType, requireAssignableTo } from "@fluidframework/build-tools";
- * ```
- *
- * These test files are compiled twice: once as ESM (to `lib/`) and once as CJS (to `dist/`).
- * When TypeScript compiles them as CJS, it validates that `require()` calls would succeed at runtime.
- * Since `@fluidframework/build-tools` is ESM-only, TypeScript throws TS1479:
- *
- * > "The current file is a CommonJS module whose imports will produce 'require' calls;
- * > however, the referenced file is an ECMAScript module and cannot be imported with 'require'."
- *
- * ### The Solution
- *
- * By placing these types in a `.cts` file, TypeScript compiles them to:
- * - `typeCompatibility.cjs` - CommonJS JavaScript output
- * - `typeCompatibility.d.cts` - CommonJS type declarations
- *
- * The package.json exports are configured with conditional exports:
- *
- * ```json
- * "exports": {
- *   ".": {
- *     "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
- *     "require": { "types": "./dist/common/typeCompatibility.d.cts", "default": "./dist/common/typeCompatibility.cjs" }
- *   }
- * }
- * ```
- *
- * ### Why This Works (Type-Only Imports)
- *
- * This workaround ONLY works because the consuming code uses `import type`:
- *
- * ```ts
- * import type { TypeOnly, ... } from "@fluidframework/build-tools";
- * ```
- *
- * Type-only imports are erased during compilation - they produce NO runtime code. This means:
- *
- * 1. TypeScript sees the `require` condition in exports and finds valid CJS types (`.d.cts`)
- * 2. TypeScript is satisfied that the import COULD work at runtime (even though it won't be called)
- * 3. The compiled output contains no actual `require("@fluidframework/build-tools")` call
- *
- * If any consuming code tried to use a VALUE export (not just types) from the CJS entry point,
- * it would fail at runtime because the `.cjs` file doesn't actually export the full package API.
- *
- * ### Important Constraints
- *
- * - Only TYPE exports are available via the CJS entry point
- * - Runtime/value exports are only available via ESM (`import` from ESM contexts)
- * - Consumers must use `import type` (not `import`) when importing from CJS contexts
+ * The types defined here cannot be in build-cli because it is an ESM-only package, and these types are imported in
+ * packages that are dual-emit or CJS-only. Long term these types should move to a shared library between build-cli and
+ * build-tools.
  */
 
 /**

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -11,9 +11,7 @@ export {
 	type PackageJson,
 } from "./common/npmPackage.js";
 /**
- * The types defined here cannot be in build-cli because it is an ESM-only package, and these types are imported in
- * packages that are dual-emit or CJS-only. Long term these types should move to a shared library between build-cli and
- * build-tools.
+ * Long term these types should move to build-cli as there is no use in build-tools.
  */
 export type {
 	FullType,
@@ -23,8 +21,8 @@ export type {
 	TypeOnly,
 } from "./common/typeCompatibility.js";
 export { getTypeTestPreviousPackageDetails } from "./common/typeTests.js";
-export { type IFluidBuildConfig } from "./fluidBuild/fluidBuildConfig.js";
-export { type IFluidCompatibilityMetadata } from "./fluidBuild/fluidCompatMetadata.js";
+export type { IFluidBuildConfig } from "./fluidBuild/fluidBuildConfig.js";
+export type { IFluidCompatibilityMetadata } from "./fluidBuild/fluidCompatMetadata.js";
 export { FluidRepo } from "./fluidBuild/fluidRepo.js";
 // For repo policy check
 export {

--- a/build-tools/packages/build-tools/tsconfig.json
+++ b/build-tools/packages/build-tools/tsconfig.json
@@ -16,6 +16,6 @@
 		"moduleResolution": "node16",
 		"types": ["node"],
 	},
-	"include": ["src/**/*.ts", "src/**/*.cts"],
+	"include": ["src/**/*.ts"],
 	"exclude": ["src/test/**/*", "dist", "node_modules"],
 }


### PR DESCRIPTION
Use a stub .d.cts file to workaround TypeScript CJS->ESM error.

Revert remaining changes from d91123e25fb80b92daff4eda1d15339de934e89c.

Update documentation.